### PR TITLE
Stlyle edits (only)

### DIFF
--- a/fast-matrix.lisp
+++ b/fast-matrix.lisp
@@ -4,10 +4,12 @@
 
 
 (defun %check-two-matrices (fst snd)
-  "fst and snd are cons of a form (height width) in this case.
-   The function returns the dimensions of resulting thing and the number of
-   multiplications requred. I work under assertion, that those matrices are
-   actually multipliable => (= (cdr fst) (car snd))."
+  #.(format
+     nil "~@{~A~%~}"
+     "fst and snd are cons of a form (height width) in this case."
+     "The function returns the dimensions of resulting thing and the number of"
+     "multiplications requred. I work under assertion, that those matrices are"
+     "actually multipliable => (= (cdr fst) (car snd)).")
   (destructuring-bind (first-height first-width) fst
     (destructuring-bind (sec-height sec-width) snd
       (list (list first-height sec-width) (* first-width sec-height sec-width)))))

--- a/fast-matrix.lisp
+++ b/fast-matrix.lisp
@@ -3,21 +3,21 @@
 (in-package #:fast-matrix)
 
 
-(defun %check-two-matrices (fst snd)
+(defun %check-two-matrices (first second)
   #.(format
      nil "~@{~A~%~}"
-     "fst and snd are cons of a form (height width) in this case."
+     "first and second are cons of a form (height width) in this case."
      "The function returns the dimensions of resulting thing and the number of"
      "multiplications requred. I work under assertion, that those matrices are"
-     "actually multipliable => (= (cdr fst) (car snd)).")
-  (destructuring-bind (first-height first-width) fst
-    (destructuring-bind (sec-height sec-width) snd
+     "actually multipliable => (= (cdr first) (car second)).")
+  (destructuring-bind (first-height first-width) first
+    (destructuring-bind (sec-height sec-width) second
       (list (list first-height sec-width) (* first-width sec-height sec-width)))))
 
-(defun %add-two-cases (fst snd)
+(defun %add-two-cases (first second)
   "Compares two cases of what previous thing returns and returns the best one."
-  (destructuring-bind (first-matrix first-mult) fst
-    (destructuring-bind (sec-matrix sec-mult) snd
+  (destructuring-bind (first-matrix first-mult) first
+    (destructuring-bind (sec-matrix sec-mult) second
       (let ((res (%check-two-matrices first-matrix sec-matrix)))
         (incf (second res) first-mult)
         (incf (second res) sec-mult)

--- a/fast-matrix.lisp
+++ b/fast-matrix.lisp
@@ -75,6 +75,13 @@
          (dimension-vector (make-array (length matrices) :initial-contents dimensions))
          (naive-time (%straight-forward-check dimensions)))
     (destructuring-bind (tree size multiplications) (%build-tree dimension-vector)
-      (format t "The resulting matrix dimensions: ~s~%Required atomic multiplications: ~s~%Compared to: ~s multiplications in naive implementation~%Acceleration ratio is ~s~%"
-              size multiplications naive-time (float (/ naive-time multiplications)))
+      (format t "~@{~A ~s~%~}"
+              "The resulting matrix dimensions:"
+              size
+              "Required atomic multiplications:"
+              multiplications
+              "Compared to multiplications in naive implementation:"
+              naive-time
+              "Acceleration ratio is:"
+              (float (/ naive-time multiplications)))
       (%index->matrix mult-function tree matrices))))

--- a/package.lisp
+++ b/package.lisp
@@ -1,4 +1,5 @@
 ;;;; package.lisp
 
 (defpackage #:fast-matrix
-  (:use #:cl))
+  (:use #:cl)
+  (:export :fast-matrix))


### PR DESCRIPTION
These commits can be cherry-picked if you don't want all of them.

- Export `fast-multiply` in `package.lisp`
- Use read-time format to get well-formatted docstrings.
- rename fst/snd to first/second.

A few questions:
- Why prefix things with `%`? Maybe do not do that.
- What is going on with `%build-tree`? Maybe use `iterate` so you can use macros in it? Definitely needs some refactoring.